### PR TITLE
slight upgrade of dependencies

### DIFF
--- a/mapsforge_flutter/pubspec.yaml
+++ b/mapsforge_flutter/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
 
   # MIT License
-  xml: 3.4.1
+  xml: 3.5.0
 
   # Apache 2.0 License
   rxdart: "0.21.0"
@@ -37,7 +37,7 @@ dependencies:
   image: 2.1.4
 
   # BSD License
-  path_provider: 1.1.0
+  path_provider: 1.1.2
 
   # MIT License
   provider: 3.0.0+1


### PR DESCRIPTION
This is what would be currently necessary to keep compatibility for mixed use with flutter_map, latest pub version. Would be nice if you could allow that.
I didn't have any issues in mapsforge_flutter using them.