### PR TITLE
external renderthemes

### DIFF
--- a/mapsforge_flutter/lib/src/mapfile/mapfileheader.dart
+++ b/mapsforge_flutter/lib/src/mapfile/mapfileheader.dart
@@ -1,6 +1,6 @@
 import 'package:logging/logging.dart';
 
-import 'file:///E:/develop/github_mapsforge_flutter/mapsforge_flutter/lib/src/exceptions/mapfileexception.dart';
+import 'package:mapsforge_flutter/src/exceptions/mapfileexception.dart';
 import 'optionalfields.dart';
 import 'readbuffer.dart';
 import 'requiredfields.dart';

--- a/mapsforge_flutter/lib/src/rendertheme/renderinstruction/bitmapmixin.dart
+++ b/mapsforge_flutter/lib/src/rendertheme/renderinstruction/bitmapmixin.dart
@@ -78,7 +78,7 @@ class BitmapMixin {
   }
 
   @protected
-  Future<Bitmap> getOrCreateBitmap(GraphicFactory graphicFactory, String relativePathPrefix, String src) async {
+  Future<Bitmap> getOrCreateBitmap(GraphicFactory graphicFactory, String src) async {
     if (bitmapInvalid) return null;
     if (null == src || src.isEmpty) {
       bitmapInvalid = true;

--- a/mapsforge_flutter/lib/src/rendertheme/renderinstruction/rendersymbol.dart
+++ b/mapsforge_flutter/lib/src/rendertheme/renderinstruction/rendersymbol.dart
@@ -18,9 +18,8 @@ class RenderSymbol extends RenderInstruction with BitmapMixin {
   Display display;
   String id;
   int priority = 0;
-  final String relativePathPrefix;
 
-  RenderSymbol(GraphicFactory graphicFactory, DisplayModel displayModel, this.relativePathPrefix) : super(graphicFactory, displayModel) {
+  RenderSymbol(GraphicFactory graphicFactory, DisplayModel displayModel) : super(graphicFactory, displayModel) {
     this.symbolCache = graphicFactory.symbolCache;
     this.display = Display.IFSPACE;
   }
@@ -98,7 +97,7 @@ class RenderSymbol extends RenderInstruction with BitmapMixin {
   /// Returns the specified bitmap or null if loading the bitmap fails
   ///
   Future<Bitmap> getBitmap(GraphicFactory graphicFactory) async {
-    return getOrCreateBitmap(graphicFactory, relativePathPrefix, src);
+    return getOrCreateBitmap(graphicFactory, src);
   }
 
   @override

--- a/mapsforge_flutter/lib/src/rendertheme/xml/renderthemebuilder.dart
+++ b/mapsforge_flutter/lib/src/rendertheme/xml/renderthemebuilder.dart
@@ -96,7 +96,7 @@ class RenderThemeBuilder {
           throw Exception("Invalid node ${node.nodeType.toString()}");
           break;
         case XmlNodeType.COMMENT:
-          throw Exception("Invalid node ${node.nodeType.toString()}");
+          // throw Exception("Invalid node ${node.nodeType.toString()}");
           break;
         case XmlNodeType.DOCUMENT:
           throw Exception("Invalid node ${node.nodeType.toString()}");
@@ -200,6 +200,9 @@ class RenderThemeBuilder {
               //hillShadings.add(hillshading);
 //      }
               //print("Time ${DateTime.now().millisecondsSinceEpoch - time} after hillshading");
+              break;
+            } else if ("stylemenu" == element.name.toString()) {
+              // TODO handle this case (Andrea)
               break;
             }
             throw Exception("Invalid node ${element.name.toString()}");

--- a/mapsforge_flutter/lib/src/rendertheme/xml/rulebuilder.dart
+++ b/mapsforge_flutter/lib/src/rendertheme/xml/rulebuilder.dart
@@ -344,7 +344,7 @@ class RuleBuilder {
 //          getStringAttribute("defaultvalue"));
     } else if ("symbol" == qName) {
       checkState(qName, XmlElementType.RENDERING_INSTRUCTION);
-      RenderSymbol symbol = new RenderSymbol(this.graphicFactory, this.displayModel, null);
+      RenderSymbol symbol = new RenderSymbol(this.graphicFactory, this.displayModel);
       symbol.parse(rootElement, initPendings);
       if (isVisible(symbol)) {
         this.addRenderingInstruction(symbol);


### PR DESCRIPTION
This pull request allows the use of external render themes with file based resources.

Some comments:

* the codebase has passed many changes since my last try, so I changed strategy
* I added a constructor to the FileSymbolCache, to allow a relative path to be supplied, so that everything would stay inside the cache object. It is not beautiful, but honestly i would not know another way. And the cache object can be created based on an asset or an external resource, so...
* there are two places that are I have a huge doubt about, but have no idea how to solve:

### case 1
```
  Future<ByteData> fetchResource(String src) async {
    if (bundle == null) {
      // TODO how to handle this case (Andrea)
      return null;
    }
    ByteData content = await bundle.load(src);
    return content;
  }
```
I hope this one is meant to be a private method, in which case the if is not necessary. If instead it can be accessed from outside, there can be issues if the cache is not bundle based.

### case 2

Two things I bypassed in the renderthemebuilder:

```
        case XmlNodeType.COMMENT:
          // throw Exception("Invalid node ${node.nodeType.toString()}");
          break;
```
This is something that appears for example in the elevate theme xml, so i would remove it if it doesn't cause trouble.

And a bit below:
```
 } else if ("stylemenu" == element.name.toString()) {
              // TODO handle this case (Andrea)
              break;
            }
```
Also something I found in the elevate theme xml. 

I am sure you can make sense of these and decide what's best.

I have been able to load an elevate theme in my app using something like:
```
    String content;
    var parentFolder = FileUtilities.parentFolderFromFile(_mapsforgeFile.path);
    var nameNoExt = FileUtilities.nameFromFile(_mapsforgeFile.path, false);
    var resourcesFolderPath = FileUtilities.joinPaths(parentFolder, nameNoExt);
    Directory resourcesFolderFile = Directory(resourcesFolderPath);
    File xmlFile;
    String relativePath;
    if (resourcesFolderFile.existsSync()) {
      // check if rendertheme xml exists
      var xmlPath = resourcesFolderPath + ".xml";
      xmlFile = File(xmlPath);
      if (xmlFile.existsSync()) {
        relativePath = resourcesFolderPath;
        content = FileUtilities.readFile(xmlPath);
      }
    }
    SymbolCache symbolCache;
    if (content == null) {
      content = await rootBundle.loadString("assets/defaultrender.xml");
      symbolCache = FileSymbolCache(rootBundle);
    } else {
      symbolCache = FileSymbolCache.withRelativePathPrefix(relativePath);
    }
```

and the result is (using the europe map from https://www.openandromaps.org/en/downloads/europe) is a bit strange, for what the forest part concerns. The contourlines indeed appear as they should, but I see tile patterns appearing in the forest polygons part:

![image](https://user-images.githubusercontent.com/390250/105470226-938a5400-5c99-11eb-9415-c26b6e2459cf.png)

Not sure how to work with that, the same map without external render theme looks correct:
![image](https://user-images.githubusercontent.com/390250/105470581-07c4f780-5c9a-11eb-8b46-7f16dd66a510.png)





