### PR TITLE
Feature alignment of Marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 mapsforge_flutter/pubspec.lock
 mapsforge_flutter/.metadata
+.vscode/
 .idea/
 example/.metadata
 example/pubspec.lock

--- a/mapsforge_flutter/CHANGELOG.md
+++ b/mapsforge_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next
+
+* Add Alignment property to BasicPointMarker + use Alignment when painting PoiMarker. Default is Alignment.bottomCenter.
+
 ## (2.0.2) - 2022-10-26
 
 * Improved speed

--- a/mapsforge_flutter/lib/src/marker/basicmarker.dart
+++ b/mapsforge_flutter/lib/src/marker/basicmarker.dart
@@ -11,6 +11,7 @@ abstract class BasicPointMarker<T> extends BasicMarker<T> implements ILatLong {
   /// The position in the map if the current marker is a "point". For path this makes no sense so a pathmarker must control its own position
   ///
   ILatLong latLong;
+  Alignment alignment;
 
   BasicPointMarker({
     display = Display.ALWAYS,
@@ -19,6 +20,7 @@ abstract class BasicPointMarker<T> extends BasicMarker<T> implements ILatLong {
     required this.latLong,
     T? item,
     MarkerCaption? markerCaption,
+    this.alignment = Alignment.center,
   })  : assert(minZoomLevel >= 0),
         assert(maxZoomLevel <= 65535),
         assert(minZoomLevel <= maxZoomLevel),

--- a/mapsforge_flutter/lib/src/marker/poimarker.dart
+++ b/mapsforge_flutter/lib/src/marker/poimarker.dart
@@ -29,6 +29,7 @@ class PoiMarker<T> extends BasicPointMarker<T> with BitmapSrcMixin {
     T? item,
     MarkerCaption? markerCaption,
     required DisplayModel displayModel,
+    Alignment alignment = Alignment.center,
   })  : assert(minZoomLevel >= 0),
         assert(maxZoomLevel <= 65535),
         assert(rotation >= 0 && rotation <= 360),
@@ -41,6 +42,7 @@ class PoiMarker<T> extends BasicPointMarker<T> with BitmapSrcMixin {
           maxZoomLevel: maxZoomLevel,
           item: item,
           latLong: latLong,
+          alignment: alignment,
         ) {
     this.bitmapSrc = src;
     this.setBitmapWidth((width * displayModel.getFontScaleFactor()).round());
@@ -61,9 +63,14 @@ class PoiMarker<T> extends BasicPointMarker<T> with BitmapSrcMixin {
     bitmap?.dispose();
     bitmap = null;
     bitmap = await loadBitmap(10, symbolCache);
+
     if (bitmap != null) {
-      _imageOffsetX = -bitmap!.getWidth() / 2;
-      _imageOffsetY = -bitmap!.getHeight() / 2;
+      double centerX = bitmap!.getWidth() / 2;
+      double centerY = bitmap!.getHeight() / 2;
+
+      _imageOffsetX = -(alignment.x * centerX + centerX);
+      _imageOffsetY = -(alignment.y * centerY + centerY);
+
       if (markerCaption != null) {
         markerCaption!
             .setDy(bitmap!.getHeight() / 2 + markerCaption!.getFontSize() / 2);

--- a/simplified_example/CHANGELOG.md
+++ b/simplified_example/CHANGELOG.md
@@ -1,3 +1,8 @@
+## next
+
+* Add marker.svg
+* Add functionality to add a PoiMarker after longTap on Map
+
 ## [1.0.1] - 2022-08-13
 
 * Use git repo as dependency

--- a/simplified_example/README.md
+++ b/simplified_example/README.md
@@ -10,3 +10,4 @@ Note:
 - Download a MapsForge map from, for example, one of the servers mentioned by [mapforge.org](https://download.mapsforge.org/), to your client. The example uses a downloaded map of [Berlin](https://download.mapsforge.org/maps/v5/europe/germany/berlin.map).
 
 - In `main.dart`, on line 42, update the path to your downloaded map.
+- Using a long tap, a marker can be added to the Map.

--- a/simplified_example/assets/icons/marker.svg
+++ b/simplified_example/assets/icons/marker.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 365 560" enable-background="new 0 0 365 560" xml:space="preserve">
+<g>
+	<path fill="#FF0000" d="M182.9,551.7c0,0.1,0.2,0.3,0.2,0.3S358.3,283,358.3,194.6c0-130.1-88.8-186.7-175.4-186.9
+		C96.3,7.9,7.5,64.5,7.5,194.6c0,88.4,175.3,357.4,175.3,357.4S182.9,551.7,182.9,551.7z M122.2,187.2c0-33.6,27.2-60.8,60.8-60.8
+		c33.6,0,60.8,27.2,60.8,60.8S216.5,248,182.9,248C149.4,248,122.2,220.8,122.2,187.2z"/>
+</g>
+</svg>

--- a/simplified_example/lib/main.dart
+++ b/simplified_example/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:mapsforge_flutter/core.dart';
 import 'package:mapsforge_flutter/maps.dart';
+import 'package:mapsforge_flutter/marker.dart';
 
 void main() {
   runApp(const MyApp());
@@ -33,8 +33,11 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  late final MapModel mapModel;
-  late final ViewModel viewModel;
+  late MapModel mapModel;
+  late ViewModel viewModel;
+
+  final MarkerDataStore markerDataStore = MarkerDataStore();
+  PoiMarker? marker;
 
   @override
   void dispose() {
@@ -72,9 +75,34 @@ class _MyHomePageState extends State<MyHomePage> {
       renderer: jobRenderer,
     );
 
+    // Add MarkerDataStore to hold added markers
+    mapModel.markerDataStores.add(markerDataStore);
+
     viewModel = ViewModel(displayModel: displayModel);
     viewModel.setMapViewPosition(52.5211, 13.3905);
     viewModel.setZoomLevel(16);
+
+
+    // Listen to longTap and add marker
+    viewModel.observeLongTap.listen((event) async {
+      if (marker != null) {
+        markerDataStore.removeMarker(marker!);
+      }
+
+      marker = PoiMarker(
+        displayModel: DisplayModel(),
+        src: 'assets/icons/marker.svg',
+        height: 64,
+        width: 48,
+        latLong: LatLong(event.latitude, event.longitude),
+        alignment: Alignment.bottomCenter
+      );
+
+      await marker!.initResources(symbolCache);
+      markerDataStore.addMarker(marker!);
+
+      setState(() {});
+    });
   }
 
   @override


### PR DESCRIPTION
I've added Alignment property to BasicPointMarker and only used it to calculate the offset for PoiMarker. I don't see a use case for CircleMarker, RectMarker and others.

mapsforge_flutter:
- Add Alignment property to BasicPointMarker.
- Use Alignment property to calculate offset of Marker.
- Updated CHANGELOG using "next" entry

simplyfied_example 
- Add functionality to add PoiMarker on longTap
- Updated CHANGELOG using "next" entry