### PR TITLE
Add positioning params to zoom_overlay.dart

### DIFF
--- a/mapsforge_flutter/lib/src/view/zoom_overlay.dart
+++ b/mapsforge_flutter/lib/src/view/zoom_overlay.dart
@@ -1,11 +1,20 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:mapsforge_flutter/core.dart';
 
 /// Shows zoom-in and zoom-out buttons
 class ZoomOverlay extends StatefulWidget {
   final ViewModel viewModel;
+  final double? top;
+  final double? right;
+  final double? bottom;
+  final double? left;
+  
 
-  ZoomOverlay(this.viewModel);
+  ZoomOverlay(this.viewModel, {this.top, this.right, this.bottom, this.left}) :
+  assert(!(top != null && bottom != null)),
+  assert(!(right != null && left != null));
 
   @override
   State<StatefulWidget> createState() {
@@ -51,43 +60,51 @@ class _ZoomOverlayState extends State<ZoomOverlay>
   @override
   Widget build(BuildContext context) {
     _fadeAnimationController.forward();
+    
     return Positioned(
-      bottom: toolbarSpacing + kBottomNavigationBarHeight,
-      right: toolbarSpacing,
+      top: widget.top != null ? max(widget.top!, toolbarSpacing) : null,
+      right: (widget.right == null && widget.left == null)
+          ? toolbarSpacing
+          : widget.right != null
+              ? max(widget.right!, toolbarSpacing)
+              : null,
+      bottom: (widget.top == null && widget.bottom == null)
+          ? toolbarSpacing
+          : widget.bottom != null
+              ? max(widget.bottom!, toolbarSpacing)
+              : null,
+      left: widget.left != null ? max(widget.left!, toolbarSpacing) : null,
+
       //top: toolbarSpacing,
       // this widget has an unbound width
       // left: toolbarSpacing,
-      child: Padding(
-        padding: const EdgeInsets.only(
-            bottom: kBottomNavigationBarHeight),
-        child: FadeTransition(
-          opacity: _fadeAnimationController,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              RawMaterialButton(
-                onPressed: () => widget.viewModel.zoomIn(),
-                elevation: 2.0,
-                fillColor: Colors.white,
-                child: const Icon(Icons.add),
-                padding: const EdgeInsets.all(10.0),
-                shape: const CircleBorder(),
-                constraints: const BoxConstraints(),
-                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-              SizedBox(height: toolbarSpacing),
-              RawMaterialButton(
-                onPressed: () => widget.viewModel.zoomOut(),
-                elevation: 2.0,
-                fillColor: Colors.white,
-                child: const Icon(Icons.remove),
-                padding: const EdgeInsets.all(10.0),
-                shape: const CircleBorder(),
-                constraints: const BoxConstraints(),
-                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-            ],
-          ),
+      child: FadeTransition(
+        opacity: _fadeAnimationController,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            RawMaterialButton(
+              onPressed: () => widget.viewModel.zoomIn(),
+              elevation: 2.0,
+              fillColor: Colors.white,
+              child: const Icon(Icons.add),
+              padding: const EdgeInsets.all(10.0),
+              shape: const CircleBorder(),
+              constraints: const BoxConstraints(),
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            SizedBox(height: toolbarSpacing),
+            RawMaterialButton(
+              onPressed: () => widget.viewModel.zoomOut(),
+              elevation: 2.0,
+              fillColor: Colors.white,
+              child: const Icon(Icons.remove),
+              padding: const EdgeInsets.all(10.0),
+              shape: const CircleBorder(),
+              constraints: const BoxConstraints(),
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
Added optional named parameters `top`, `right`, `bottom` and `left` to allow the ZoomOverlay to be positioned anywhere on the map.

I've also altered the use of spacing applied to the widget.