### PR TITLE
Set color of ZoomOverlay buttons according to theme

### DIFF
--- a/lib/src/view/zoom_overlay.dart
+++ b/lib/src/view/zoom_overlay.dart
@@ -60,7 +60,11 @@ class _ZoomOverlayState extends State<ZoomOverlay>
   @override
   Widget build(BuildContext context) {
     _fadeAnimationController.forward();
-    
+
+    final brightness = MediaQuery.platformBrightnessOf(context);
+    final fillColor = Theme.of(context).buttonTheme.colorScheme?.surface ?? 
+      (brightness == Brightness.light ? Colors.white : Colors.black);
+
     return Positioned(
       top: widget.top != null ? max(widget.top!, toolbarSpacing) : null,
       right: (widget.right == null && widget.left == null)
@@ -86,7 +90,7 @@ class _ZoomOverlayState extends State<ZoomOverlay>
             RawMaterialButton(
               onPressed: () => widget.viewModel.zoomIn(),
               elevation: 2.0,
-              fillColor: Colors.white,
+              fillColor: fillColor,
               child: const Icon(Icons.add),
               padding: const EdgeInsets.all(10.0),
               shape: const CircleBorder(),
@@ -97,7 +101,7 @@ class _ZoomOverlayState extends State<ZoomOverlay>
             RawMaterialButton(
               onPressed: () => widget.viewModel.zoomOut(),
               elevation: 2.0,
-              fillColor: Colors.white,
+              fillColor: fillColor,
               child: const Icon(Icons.remove),
               padding: const EdgeInsets.all(10.0),
               shape: const CircleBorder(),

--- a/simplified_example/lib/main.dart
+++ b/simplified_example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:logging/logging.dart';
 import 'package:mapsforge_flutter/core.dart';
 import 'package:mapsforge_flutter/maps.dart';
 import 'package:mapsforge_flutter/marker.dart';
+import 'package:mapsforge_flutter/overlay.dart';
 
 void main() {
   runApp(MyApp());
@@ -22,6 +23,11 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
+      darkTheme: ThemeData(
+        primarySwatch: Colors.blue,
+        brightness: Brightness.dark,
+      ),
+      themeMode: ThemeMode.system,
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
@@ -99,6 +105,7 @@ class _MyHomePageState extends State<MyHomePage> {
       symbolCache: symbolCache,
       displayModel: displayModel,
     ));
+    viewModel.addOverlay(ZoomOverlay(viewModel));
     return viewModel;
   }
 


### PR DESCRIPTION
Currently, when selecting a darkTheme, the text of the icons shown in the buttons are shown according the current theme:
- theme: Text '+' and '-' are black
- darkTheme: Text '+' and '-' are white

Because the 'fillColor' of the zoom buttons is hardcoded `Colors.white`, the labels will be white on white when using a dark theme.

Changes made:
- Set the `fillColor` according the  `ButtonTheme.colorScheme.surface` of the current theme , with fallback defaulting to `Color.white` when using light theme and `Colors.black` when using a dark theme.
- Add darkTheme to simplified example.
- Add ZoomOverlay to ViewModel in simplified example

The user can now also override the `fillColor` by using for example:
```
viewModel.addOverlay(
      Theme(
        data: Theme.of(context).copyWith(
          buttonTheme: Theme.of(context).buttonTheme.copyWith(
                colorScheme: Theme.of(context)
                    .buttonTheme
                    .colorScheme
                    ?.copyWith(surface: Colors.red),
              ),
        ),
        child: ZoomOverlay(viewModel),
      ),
    );
```