### PR TITLE
Extend rotation gesture with options to reset and add widget to recenter

### DIFF
--- a/packages/mapsforge_flutter/lib/src/gesture/rotation_gesture_detector.dart
+++ b/packages/mapsforge_flutter/lib/src/gesture/rotation_gesture_detector.dart
@@ -1,23 +1,70 @@
 import 'dart:math';
-
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mapsforge_flutter/mapsforge.dart';
 
-/// Two‐finger rotation overlay that never blocks pan/zoom,
-/// and uses ViewModel.rotateDelta() to apply each twist incrementally.
 class RotationGestureDetector extends StatefulWidget {
   final MapModel mapModel;
 
   /// degrees of twist before we start rotating
   final double thresholdDeg;
 
-  const RotationGestureDetector({super.key, required this.mapModel, this.thresholdDeg = 10.0});
+  /// If true, rotation gestures are ignored (pan/zoom unaffected).
+  final bool locked;
+
+  /// Optional reset control widget.
+  final Widget? resetChild;
+
+  /// Use Positioned() style placement; null values are ignored.
+  final double? left, top, right, bottom;
+
+  /// Padding around the reset control (inside the Positioned area).
+  final EdgeInsetsGeometry resetPadding;
+
+  /// Hide resetChild when map rotation is effectively zero.
+  final bool hideResetWhenZero;
+
+  /// Epsilon to consider "not rotated".
+  final double zeroEpsilonDeg;
+
+  /// Preferred: listenable rotation in degrees, used to drive visibility.
+  final ValueListenable<double>? rotationDeg;
+
+  /// Fallback: compute "is rotated" on demand (used if [rotationDeg] is null).
+  final bool Function()? isRotated;
+
+  /// Degrees to reset to when tapped. Ignored if [onReset] is provided.
+  final double resetToDegrees;
+
+  final bool wrapResetChildTap;
+
+  /// Optional custom reset handler.
+  final VoidCallback? onReset;
+
+  const RotationGestureDetector({
+    super.key,
+    required this.mapModel,
+    this.thresholdDeg = 10.0,
+    this.locked = false,
+    this.resetChild,
+    this.left,
+    this.top,
+    this.right,
+    this.bottom,
+    this.resetPadding = const EdgeInsets.all(12),
+    this.hideResetWhenZero = true,
+    this.zeroEpsilonDeg = 0.5,
+    this.rotationDeg,
+    this.isRotated,
+    this.resetToDegrees = 0.0,
+    this.onReset,
+    this.wrapResetChildTap = true,
+  });
 
   @override
-  State<RotationGestureDetector> createState() => _RotationGestureDetectorState();
+  State<RotationGestureDetector> createState() =>
+      _RotationGestureDetectorState();
 }
-
-//////////////////////////////////////////////////////////////////////////////
 
 class _RotationGestureDetectorState extends State<RotationGestureDetector> {
   final Map<int, Offset> _points = {};
@@ -32,16 +79,29 @@ class _RotationGestureDetectorState extends State<RotationGestureDetector> {
   double _twoFingerAngle() {
     final pts = _points.values.toList();
     final theta = atan2(pts[1].dy - pts[0].dy, pts[1].dx - pts[0].dx);
-    // range -pi .. +pi. 0 is from left to right (positive x-axis)
-    // converted to degrees
     return _normalize(theta * 180 / pi);
   }
 
-  @override
-  Widget build(BuildContext context) {
+  void _performReset() {
+    if (widget.onReset != null) {
+      widget.onReset!();
+    } else {
+      try {
+        widget.mapModel.rotateTo(widget.resetToDegrees);
+      } catch (_) {
+        // No-op fallback.
+      }
+    }
+    _rotating = false;
+    _baselineAngle = null;
+    setState(() {}); // in case visibility depends on rebuild
+  }
+
+  Widget _buildGestureOverlay() {
     return Listener(
       behavior: HitTestBehavior.translucent,
       onPointerDown: (e) {
+        if (widget.locked) return;
         _points[e.pointer] = e.position;
         if (_points.length == 2) {
           _baselineAngle = _twoFingerAngle();
@@ -49,6 +109,7 @@ class _RotationGestureDetectorState extends State<RotationGestureDetector> {
         }
       },
       onPointerMove: (e) {
+        if (widget.locked) return;
         if (!_points.containsKey(e.pointer)) return;
         _points[e.pointer] = e.position;
 
@@ -58,19 +119,15 @@ class _RotationGestureDetectorState extends State<RotationGestureDetector> {
           if (delta > 180) delta -= 360;
           if (delta < -180) delta += 360;
 
-          // threshold guard
           if (!_rotating) {
             if (delta.abs() > widget.thresholdDeg) {
               _rotating = true;
             } else {
-              return; // still just pinch/drag
+              return; // still pinch/drag
             }
           }
 
-          // apply only the incremental twist
           widget.mapModel.rotateBy(delta);
-
-          // reset baseline for the next small delta
           _baselineAngle = newAngle;
         }
       },
@@ -89,6 +146,72 @@ class _RotationGestureDetectorState extends State<RotationGestureDetector> {
         }
       },
       child: const SizedBox.expand(),
+    );
+  }
+
+  bool _computeIsRotated() {
+    if (!widget.hideResetWhenZero) return true;
+    if (widget.rotationDeg != null) {
+      return widget.rotationDeg!.value.abs() > widget.zeroEpsilonDeg;
+    }
+    if (widget.isRotated != null) {
+      return widget.isRotated!();
+    }
+    // If we can’t know, default to showing it.
+    return true;
+  }
+
+  Widget _positionedResetChild(Widget child) {
+    return Positioned(
+      left: widget.left,
+      top: widget.top,
+      right: widget.right,
+      bottom: widget.bottom,
+      child: Padding(
+        padding: widget.resetPadding,
+        child: widget.wrapResetChildTap
+            ? GestureDetector(onTap: _performReset, child: widget.resetChild!)
+            : widget.resetChild!,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final overlay = _buildGestureOverlay();
+
+    if (widget.resetChild == null) {
+      return overlay;
+    }
+
+    // If we have a listenable rotation, use it to rebuild/hide automatically.
+    if (widget.rotationDeg != null) {
+      return Stack(
+        fit: StackFit.expand,
+        children: [
+          overlay,
+          ValueListenableBuilder<double>(
+            valueListenable: widget.rotationDeg!,
+            builder: (_, angle, __) {
+              final visible =
+                  !widget.hideResetWhenZero ||
+                  angle.abs() > widget.zeroEpsilonDeg;
+              if (!visible) return const SizedBox.shrink();
+              return _positionedResetChild(widget.resetChild!);
+            },
+          ),
+        ],
+      );
+    }
+
+    // Fallback: single-shot check; parent should rebuild when rotation changes.
+    final visible = _computeIsRotated();
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        overlay,
+        if (visible) _positionedResetChild(widget.resetChild!),
+      ],
     );
   }
 }


### PR DESCRIPTION
Since my app required the ability to recenter the map and I did not find a suitable option I decided to extend the rotation gesture widget.

Here is how to use the newly introduced functions:

when adding the RotationGestureDetector to your map, there are new exposed properties:

```
    RotationGestureDetector(
      mapModel: model,
      locked: locked,
      thresholdDeg: 10,
      resetChild: _buildResetFab(model),
      right: 16,
      top: 16 + 40 + 12,
      resetPadding: const EdgeInsets.all(0),
      rotationDeg: model.rotationNotifier,
    ),
```

example reset fab button:

```
  Widget _buildResetFab(MapModel model) {
    return SizedBox(
      width: 40,
      height: 40,
      child: Theme(
        data: Theme.of(context).copyWith(
          floatingActionButtonTheme: const FloatingActionButtonThemeData(
            backgroundColor: Colors.transparent,
            elevation: 0,
            focusElevation: 0,
            hoverElevation: 0,
            disabledElevation: 0,
          ),
        ),
        child: FloatingActionButton(
          mini: true,
          heroTag: 'reset_rotation_fab',
          onPressed: () => model.rotateTo(0),
          shape: const CircleBorder(),
          child: _circleIconWithIcon(Icons.explore),
        ),
      ),
    );
  }
```

By passing a value to locked you can either enable/disable the rotation, by your preferred method

