### PR TITLE
Limit LabelView painting when zoom level is low

### DIFF
--- a/packages/mapsforge_flutter/lib/src/label/label_view.dart
+++ b/packages/mapsforge_flutter/lib/src/label/label_view.dart
@@ -47,7 +47,6 @@ class _LabelViewState extends State<LabelView> {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        // Be defensive in case scale factor is unavailable early.
         final double scale = MapsforgeSettingsMgr().getDeviceScaleFactor();
 
         jobQueue.setSize(

--- a/packages/mapsforge_flutter/lib/src/label/label_view.dart
+++ b/packages/mapsforge_flutter/lib/src/label/label_view.dart
@@ -6,13 +6,21 @@ import 'package:mapsforge_flutter/src/label/label_set.dart';
 import 'package:mapsforge_flutter/src/transform_widget.dart';
 import 'package:mapsforge_flutter_core/utils.dart';
 
-/// A view to display the labels. The view updates itself whenever the [MapPosition] changes and new labels are available. This only works if
-/// the renderer supports labels. The labels will NOT be rendered into the tiles but instead drawn separately so that the labels are always
-/// facing in the same orientation.
+/// A view to display the labels. The view updates itself whenever the [MapPosition] changes and new labels are available.
+/// Labels are drawn separately so they keep orientation.
+///
+/// Set [minLabelZoom] to hide labels below a given zoom. If null, suppression is disabled.
 class LabelView extends StatefulWidget {
   final MapModel mapModel;
 
-  const LabelView({super.key, required this.mapModel});
+  /// Hide labels when zoomlevel < minLabelZoom. Null = feature disabled.
+  final int? minLabelZoom;
+
+  const LabelView({
+    super.key,
+    required this.mapModel,
+    this.minLabelZoom, // e.g. pass 10 to suppress under zoom 10
+  });
 
   @override
   State<LabelView> createState() => _LabelViewState();
@@ -39,27 +47,51 @@ class _LabelViewState extends State<LabelView> {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        /// Multiply the mappixels of the view with the scalefactor because the images will be shrinked by that factor while drawing them.
+        // Be defensive in case scale factor is unavailable early.
+        final double scale = MapsforgeSettingsMgr().getDeviceScaleFactor();
+
         jobQueue.setSize(
-          constraints.maxWidth * MapsforgeSettingsMgr().getDeviceScaleFactor(),
-          constraints.maxHeight * MapsforgeSettingsMgr().getDeviceScaleFactor(),
+          constraints.maxWidth * scale,
+          constraints.maxHeight * scale,
         );
-        return StreamBuilder(
-          stream: jobQueue.labelStream,
+
+        // If a cutoff is configured, and the last known position is below it, render nothing.
+        final cutoff = widget.minLabelZoom;
+        final last = widget.mapModel.lastPosition;
+        if (cutoff != null && last != null && last.zoomlevel < cutoff) {
+          return const SizedBox.expand();
+        }
+
+        // Optionally filter the stream when a cutoff is set.
+        final Stream<LabelSet> stream = (cutoff == null)
+            ? jobQueue.labelStream
+            : jobQueue.labelStream.where(
+                (ls) => ls.mapPosition.zoomlevel >= cutoff,
+              );
+
+        return StreamBuilder<LabelSet>(
+          stream: stream,
           builder: (BuildContext context, AsyncSnapshot<LabelSet> snapshot) {
             if (snapshot.error != null) {
-              return ErrorhelperWidget(error: snapshot.error!, stackTrace: snapshot.stackTrace);
-            }
-            if (snapshot.data != null) {
-              return TransformWidget(
-                mapCenter: snapshot.data!.center,
-                mapPosition: snapshot.data!.mapPosition,
-                screensize: Size(constraints.maxWidth, constraints.maxHeight),
-                child: CustomPaint(foregroundPainter: LabelPainter(snapshot.data!), child: const SizedBox.expand()),
+              return ErrorhelperWidget(
+                error: snapshot.error!,
+                stackTrace: snapshot.stackTrace,
               );
             }
-            // Waiting for position information of until data are available
-            return const SizedBox.expand();
+            final data = snapshot.data;
+            if (data == null) {
+              // Waiting for data or suppressed by cutoff.
+              return const SizedBox.expand();
+            }
+            return TransformWidget(
+              mapCenter: data.center,
+              mapPosition: data.mapPosition,
+              screensize: Size(constraints.maxWidth, constraints.maxHeight),
+              child: CustomPaint(
+                foregroundPainter: LabelPainter(data),
+                child: const SizedBox.expand(),
+              ),
+            );
           },
         );
       },


### PR DESCRIPTION
If you have thousands of markers on the map and you zoom out, the label view gets very laggy, so with this PR you can set the minimum zoom level when the labels (symbols) are drawn on the map.